### PR TITLE
chore(chart): update PaperMC to 26.2

### DIFF
--- a/charts/papermc/Chart.yaml
+++ b/charts/papermc/Chart.yaml
@@ -2,6 +2,8 @@ annotations:
   artifacthub.io/category: skip-prediction
   artifacthub.io/changes: |-
     - kind: changed
+      description: Update PaperMC to version 26.2
+    - kind: changed
       description: Update PaperMC to version 26.1.2
     - kind: added
       description: Add externalTrafficPolicy support for Service
@@ -17,8 +19,8 @@ apiVersion: v2
 name: papermc
 description: PaperMC Minecraft server Helm chart for Kubernetes
 type: application
-version: "0.4.0"
-appVersion: "26.1.2"
+version: "0.5.0"
+appVersion: "26.2"
 icon: https://avatars.githubusercontent.com/u/7608950?s=200&v=4
 home: https://github.com/lexfrei/papermc-docker/
 keywords:

--- a/charts/papermc/README.md
+++ b/charts/papermc/README.md
@@ -1,6 +1,6 @@
 # papermc
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.1.2](https://img.shields.io/badge/AppVersion-26.1.2-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.2](https://img.shields.io/badge/AppVersion-26.2-informational?style=flat-square)
 
 PaperMC Minecraft server Helm chart for Kubernetes
 
@@ -39,12 +39,12 @@ This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
 # Install from GHCR
 helm install papermc \
   oci://ghcr.io/lexfrei/papermc \
-  --version 0.4.0
+  --version 0.5.0
 
 # Install with custom values
 helm install papermc \
   oci://ghcr.io/lexfrei/papermc \
-  --version 0.4.0 \
+  --version 0.5.0 \
   --values values.yaml
 ```
 


### PR DESCRIPTION
## Summary

Automatic update of PaperMC version in Helm chart.

## Changes
- **appVersion**: 26.1.2 → 26.2
- **Chart version**: 0.4.0 → 0.5.0 (minor bump)
- **README.md**: Regenerated with helm-docs

After merge, the publish-chart workflow publishes the new chart version to GHCR.