### PR TITLE
fix(ci): repair the nightly chart update for calendar-versioned Paper releases

### DIFF
--- a/.github/workflows/build-paper-images.yml
+++ b/.github/workflows/build-paper-images.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install goPaperMC
         run: |
-          go install github.com/lexfrei/goPaperMC/cmd/papermc@v0.0.3
+          go install github.com/lexfrei/goPaperMC/cmd/papermc@v0.0.4
 
       - name: Get Build Matrix
         id: set-matrix

--- a/.github/workflows/build-paper-images.yml
+++ b/.github/workflows/build-paper-images.yml
@@ -32,9 +32,14 @@ jobs:
       - name: Get Latest Version
         id: set-latest
         run: |
-          # Get the latest version string
-          LATEST=$(papermc ci latest paper)
-          echo "latest=$LATEST" >> $GITHUB_OUTPUT
+          # Derive the latest version from the build matrix rather than from
+          # `papermc ci latest`, which ignores --channel and reports versions
+          # that only have pre-release builds (e.g. 26.2). The chart must track
+          # a version whose image this workflow actually builds and pushes.
+          # The matrix is ordered oldest to newest, so the last entry is latest.
+          LATEST=$(echo '${{ steps.set-matrix.outputs.matrix }}' | jq --raw-output '.include[-1].version')
+          echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
+          echo "Latest stable version: $LATEST"
 
   build:
     needs: prepare

--- a/.github/workflows/update-chart-version.yml
+++ b/.github/workflows/update-chart-version.yml
@@ -93,6 +93,20 @@ jobs:
         run: |
           BRANCH="chore/update-papermc-${{ inputs.version }}"
 
+          if [ -z "$(git status --porcelain charts/papermc)" ]; then
+            echo "Chart is already at ${{ inputs.version }}, nothing to do"
+            exit 0
+          fi
+
+          # The nightly build re-triggers this workflow for as long as the chart
+          # lags behind, so a PR for this version may already be open. Pushing the
+          # same branch again from a fresh master is a non-fast-forward and would
+          # fail every night until that PR merges.
+          if [ "$(gh pr list --head "$BRANCH" --state open --json number --jq 'length')" -gt 0 ]; then
+            echo "PR for $BRANCH is already open, nothing to do"
+            exit 0
+          fi
+
           git config user.name "lexfrei"
           git config user.email "f@lex.la"
 
@@ -104,7 +118,9 @@ jobs:
           - Bump chart version to ${{ steps.new.outputs.version }}
           - Regenerate documentation"
 
-          git push --set-upstream origin "$BRANCH"
+          # The branch can outlive a closed PR. It is fully generated, so replacing
+          # it is safe and keeps the job from tripping over its own leftovers.
+          git push --force --set-upstream origin "$BRANCH"
 
           gh pr create \
             --title "chore(chart): update PaperMC to ${{ inputs.version }}" \

--- a/charts/papermc/tests/chart_test.yaml
+++ b/charts/papermc/tests/chart_test.yaml
@@ -19,7 +19,18 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: ^lexfrei/papermc:\d+\.\d+\.\d+$
+          pattern: ^lexfrei/papermc:\d+(\.\d+){1,2}$
+
+  # Paper releases both dotted (1.21.11) and calendar (26.1.2, 26.2) versions,
+  # and calendar minors carry only two components.
+  - it: should set correct image with a calendar appVersion
+    template: statefulset.yaml
+    chart:
+      appVersion: "26.2"
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^lexfrei/papermc:\d+(\.\d+){1,2}$
 
   - it: should allow custom image tag
     template: statefulset.yaml


### PR DESCRIPTION
## Description

Three fixes to the chart-update automation, which has failed on every nightly run since 17 June.

## Related Issue

None.

## Motivation and Context

Paper now publishes calendar versions (26.x) alongside dotted ones, and three separate defects turned that into a nightly failure loop:

1. `papermc ci latest` ignores the `--channel` filter and returns 26.2 — a version that has only alpha and beta builds. The nightly job kept proposing a chart bump to a version whose image is never built, so the tag it points at would not exist in the registry.
2. The image-tag assertion required exactly three version components, so a bump to a calendar minor such as 26.2 failed the test suite and blocked the update pull request.
3. With that pull request stalled, every later nightly run recreated the same branch from master and the push was rejected as a non-fast-forward, failing the job for as long as the pull request stayed open.

The target version now comes from the stable build matrix, so the chart can only ever track a version whose image this workflow actually publishes. The update job bails out early when the chart is already current or a pull request for the version is open, and force-pushes its own generated branch so a leftover from a closed pull request cannot block it either.

## How Has This Been Tested?

- [x] Ran helm-unittest tests
- [x] Other: helm lint and actionlint are clean; the added calendar-version case fails against the old pattern and passes with the new one; matrix ordering verified against the live Paper API

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Helm chart changes

## Checklist

- [x] My code follows the code style of this project (check with `docker build` or `helm lint`)
- [x] I have checked that my changes do not break existing functionality
- [x] I have added necessary comments to the code, particularly in hard-to-understand areas
- [ ] For Helm chart changes: Chart.yaml version and changelog are not bumped — this touches only the test suite, the packaged chart is unchanged
